### PR TITLE
Removing dependency on "Messaging.Host" app settings entry

### DIFF
--- a/src/SevenDigital.Messaging.Base.Integration.Tests/Configuration/RabbitConnectionConfigurationTests.cs
+++ b/src/SevenDigital.Messaging.Base.Integration.Tests/Configuration/RabbitConnectionConfigurationTests.cs
@@ -8,6 +8,7 @@ using StructureMap;
 namespace Messaging.Base.Unit.Tests.Configuration
 {
 	[TestFixture]
+	[Obsolete("To be removed with MessagingBaseConfiguration().WithConnectionFromAppConfig()")]
     public class RabbitConnectionConfigurationTests
     {
 		IRabbitMqConnection connection;

--- a/src/SevenDigital.Messaging.Base.Integration.Tests/Configuration/RabbitQueryConfigurationTests.cs
+++ b/src/SevenDigital.Messaging.Base.Integration.Tests/Configuration/RabbitQueryConfigurationTests.cs
@@ -8,6 +8,7 @@ using StructureMap;
 namespace Messaging.Base.Unit.Tests.Configuration
 {
 	[TestFixture]
+	[Obsolete("To be removed along with MessagingBaseConfiguration().WithRabbitManagementFromAppConfig()")]
 	public class RabbitQueryConfigurationTests
 	{
 		IRabbitMqQuery query;

--- a/src/SevenDigital.Messaging.Base.Integration.Tests/EndToEnd.cs
+++ b/src/SevenDigital.Messaging.Base.Integration.Tests/EndToEnd.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 using Example.Types;
 using NUnit.Framework;
@@ -21,7 +20,7 @@ namespace Messaging.Base.Integration.Tests
 		{
 			new MessagingBaseConfiguration()
 				.WithDefaults()
-				.WithConnectionFromAppConfig();
+				.WithConnection(ConfigurationHelpers.RabbitMqConnectionWithConfigSettings());
 
 			messaging = ObjectFactory.GetInstance<IMessagingBase>();
 

--- a/src/SevenDigital.Messaging.Base.Integration.Tests/FuzzingTests.cs
+++ b/src/SevenDigital.Messaging.Base.Integration.Tests/FuzzingTests.cs
@@ -17,9 +17,8 @@ namespace Messaging.Base.Integration.Tests
 		{
 			new MessagingBaseConfiguration()
 				.WithDefaults()
-				.WithConnectionFromAppConfig();
+				.WithConnection(ConfigurationHelpers.RabbitMqConnectionWithConfigSettings());
 
-			
 			_conn = ObjectFactory.GetInstance<IChannelAction>();
 		}
 
@@ -35,9 +34,8 @@ namespace Messaging.Base.Integration.Tests
 
 			new MessagingBaseConfiguration()
 				.WithDefaults()
-				.WithConnectionFromAppConfig();
+				.WithConnection(ConfigurationHelpers.RabbitMqConnectionWithConfigSettings());
 
-			
 			var anyFails = false;
 
 			var b = new Thread(() =>

--- a/src/SevenDigital.Messaging.Base.Integration.Tests/Helpers/ConfigurationHelpers.cs
+++ b/src/SevenDigital.Messaging.Base.Integration.Tests/Helpers/ConfigurationHelpers.cs
@@ -18,6 +18,15 @@ namespace Messaging.Base.Integration.Tests
 			return new RabbitMqQuery("http://" + hostUri + ":55672", username, password, vhost); // before RMQ 3
 		}
 
+		public static RabbitMqConnection RabbitMqConnectionWithConfigSettings()
+		{
+			var parts = ConfigurationManager.AppSettings["Messaging.Host"].Split('/');
+			var hostUri = (parts.Length >= 1) ? (parts[0]) : ("localhost");
+			var vhost = (parts.Length >= 2 && parts[1].Length > 0) ? (parts[1]) : ("/");
+
+			return new RabbitMqConnection(hostUri, vhost);
+		}
+
 		static readonly IRabbitMqConnection conn;
 		static ConfigurationHelpers()
 		{

--- a/src/SevenDigital.Messaging.Base/MessagingBaseConfiguration.cs
+++ b/src/SevenDigital.Messaging.Base/MessagingBaseConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 using SevenDigital.Messaging.Base.RabbitMq;
 using SevenDigital.Messaging.Base.RabbitMq.RabbitMqManagement;
 using SevenDigital.Messaging.Base.Routing;
@@ -48,21 +49,29 @@ namespace SevenDigital.Messaging.Base
 		/// <summary>
 		/// Use details contained in .Net configuration key `Messaging.Host` for connections
 		/// </summary>
+		[Obsolete("Please use WithConnection(IRabbitMqConnection connection) instead.")]
 		public MessagingBaseConfiguration WithConnectionFromAppConfig()
 		{
-			configuredConnection = RabbitMqConnectionWithAppConfigSettings();
-			ObjectFactory.Configure(map => map.For<IRabbitMqConnection>().Use(() => configuredConnection));
-			return this;
+			var parts = ConfigurationManager.AppSettings["Messaging.Host"].Split('/');
+			var hostUri = (parts.Length >= 1) ? (parts[0]) : ("localhost");
+			var vhost = (parts.Length >= 2 && parts[1].Length > 0) ? (parts[1]) : ("/");
+
+			return WithConnection(new RabbitMqConnection(hostUri, vhost));
 		}
 
 		/// <summary>
 		/// Use details contained in .Net configuration keys `Messaging.Host`, `ApiUsername` and `ApiPassword` for connections
 		/// </summary>
+		[Obsolete("Please use WithRabbitManagement(string host, string username, string password, string vhost) instead.")]
 		public MessagingBaseConfiguration WithRabbitManagementFromAppConfig()
 		{
-			configuredQuery = RabbitMqQueryWithConfigSettings();
-			ObjectFactory.Configure(map => map.For<IRabbitMqQuery>().Use(() => configuredQuery));
-			return this;
+			var parts = ConfigurationManager.AppSettings["Messaging.Host"].Split('/');
+			var hostUri = (parts.Length >= 1) ? (parts[0]) : ("localhost");
+			var username = ConfigurationManager.AppSettings["ApiUsername"];
+			var password = ConfigurationManager.AppSettings["ApiPassword"];
+			var vhost = (parts.Length >= 2) ? (parts[1]) : ("/");
+
+			return WithRabbitManagement(hostUri, username, password, vhost);
 		}
 
 		const int port = 55672; // before RMQ 3; 3 redirects, so we use this for compatibility for now.
@@ -77,26 +86,5 @@ namespace SevenDigital.Messaging.Base
 				new RabbitMqQuery("http://" + host + ":" + port, username, password, vhost)));
 			return this;
 		}
-
-		static RabbitMqQuery RabbitMqQueryWithConfigSettings()
-		{
-			var parts = ConfigurationManager.AppSettings["Messaging.Host"].Split('/');
-			var hostUri = (parts.Length >= 1) ? (parts[0]) : ("localhost");
-			var username = ConfigurationManager.AppSettings["ApiUsername"];
-			var password = ConfigurationManager.AppSettings["ApiPassword"];
-			var vhost = (parts.Length >= 2) ? (parts[1]) : ("/");
-
-			return new RabbitMqQuery("http://" + hostUri + ":" + port, username, password, vhost);
-		}
-
-		static RabbitMqConnection RabbitMqConnectionWithAppConfigSettings()
-		{
-			var parts = ConfigurationManager.AppSettings["Messaging.Host"].Split('/');
-			var hostUri = (parts.Length >= 1) ? (parts[0]) : ("localhost");
-			var vhost = (parts.Length >= 2 && parts[1].Length > 0) ? (parts[1]) : ("/");
-
-			return new RabbitMqConnection(hostUri, vhost);
-		}
-
 	}
 }


### PR DESCRIPTION
Removing dependency on "Messaging.Host" app settings entry, public methods marked as Obsolete. Tests still use the same config file entries, but the dll used by consumers  no longer has an implicit dependency on the config.
